### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/src/app/react/index.tsx
+++ b/src/app/react/index.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 import { render } from 'react-dom'
 import { Router, Route, hashHistory} from 'react-router'
-import * as createHistory from 'history/lib/createBrowserHistory'
+import createBrowserHistory from 'history/lib/createBrowserHistory'
 
 import { App } from './components/app'
 import { About } from './components/about'
 import Tracker from './ud'
 
-const history = createHistory()
+const history = createBrowserHistory()
 const tracker = new Tracker()
 
 history.listen( history => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "node_modules",
     "typings"
   ],
-  "filesGlobs": [
+  "files": [
     "./typings/index.d.ts"
   ]
 }


### PR DESCRIPTION
## 解決したエラー

`npm run build` 時に表示されるエラー類を一部解消。

1. Cannot find module xxx.

  ```
  ERROR in ./src/app/react/index.tsx
  (1,24): error TS2307: Cannot find module 'react'.
  ```

  tsconfigs.json の `fileGlobs` は TypeScript2.0 より利用可能なため、files に指定するように変更。

1. error TS2349: Cannot invoke an expression whose type lacks a call signature.
`import * as createHistory from 'history/lib/createBrowserHistory'` がエラーになっていたため、`createBrowserHistory` を指定するように変更。

↑上記問題ないかレビューをお願いします。

## 未解決なエラー(dist/assets 以下に出力はされている)
```
ERROR in /Volumes/Data/work/ut/src/current/examples/src/app/ud.d.ts
(19,5): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.

ERROR in /Volumes/Data/work/ut/src/current/examples/src/app/ud.d.ts
(20,5): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.

ERROR in /Volumes/Data/work/ut/src/current/examples/src/app/ud.d.ts
(21,5): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.

ERROR in /Volumes/Data/work/ut/src/current/examples/src/app/ud.d.ts
(22,5): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
```
上記エラーは現状未解決だが、他のをレビューしてもらうために一旦 PR する。