### PR TITLE
ビルドエラー時のエラーを解消する

### DIFF
--- a/src/app/ud.d.ts
+++ b/src/app/ud.d.ts
@@ -15,10 +15,13 @@ interface ConfigFields {
 }
 
 declare namespace USERDIVETracker {
+  type Command = 'create'
+  type SetCustomVar = 'setCustomVar'
+  type ChangeVirtualUrl = 'changeVirtualUrl'
   interface USERDIVEObject {
-    (command: 'create', trackingId: string, config?: ConfigFields): void
-    (command: 'create', trackingIds: ConfigIds, config?: ConfigFields): void
-    (command: 'setCustomVar', customVar: CustomVar): void
-    (command: 'changeVirtualUrl', url: string): void
+    (command: Command, trackingId: string, config?: ConfigFields): void
+    (command: Command, trackingIds: ConfigIds, config?: ConfigFields): void
+    (command: SetCustomVar, customVar: CustomVar): void
+    (command: ChangeVirtualUrl, url: string): void
   }
 }


### PR DESCRIPTION
エラー内容は、以下の通り。

(19,5): error TS2382: Specialized overload signature is not assignable
to any non-specialized signature.

String Literal Types を使用することで、上記エラーを解消し、関数に与えることができる文字列に制約をかける。

http://qiita.com/vvakame/items/31f5c45ff49de67d5634#string-literal-types